### PR TITLE
fix: issue with opening pages in some iOS devices

### DIFF
--- a/wp-react-lib/src/util/index.js
+++ b/wp-react-lib/src/util/index.js
@@ -46,13 +46,16 @@ export const replaceHTMLinks = (html, locale) => {
 }
 
 export const removePatternBrackets = (html) => {
-    const bracketReplacement = `###${Math.random()}###`; //this is a workaround to skip an issue with brackets in regex and tag it for replacement
-    const regex = new RegExp(`(?<=${bracketReplacement}).*?(?=])`, 'ig');
+    const bracketReplacement = `###${Math.random()}###`; // A unique string to mark replacements
+    const regex = new RegExp(`\\[${bracketReplacement}.*?]`, 'ig'); // No lookbehind, matches pattern within square brackets
     if (html) {
-        return html.replaceAll('[:', bracketReplacement).replaceAll(regex, '').replaceAll(`${bracketReplacement}]`, '');
+        return html
+            .replaceAll('[:', `[${bracketReplacement}`) // Use square brackets to match regex pattern
+            .replaceAll(regex, '') // Remove entire pattern inside square brackets
+            .replaceAll(`${bracketReplacement}`, ''); // Clean up any remaining placeholders
     } else {
         return null;
     }
-}
+};
 
 export default {replaceHTMLinks, replaceLink}


### PR DESCRIPTION
- In some iOS and iPadOS devices, the error: invalid regular expression, invalid group specifier name occurs when you attempt to load the TCDI website. This is because the older versions of webkit do not support lookbehind regular expressions
- This fixes the issue by rewriting `removePatternBrackets` to support webkit