### PR TITLE
docs: align governance docs with project contribution policy

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,90 @@
+Our Pledge
+----------
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone.
+
+We pledge to act and interact in ways that contribute to an open, welcoming and healthy community.
+
+Our Standards
+-------------
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+-   Demonstrating empathy and kindness toward other people
+
+-   Being respectful of differing opinions, viewpoints, and experiences
+
+-   Giving and gracefully accepting constructive feedback
+
+-   Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+
+-   Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+-   The use of sexualized language or imagery, and sexual attention or advances of any kind
+
+-   Trolling, insulting or derogatory comments, and personal or political attacks
+
+-   Public or private harassment
+
+-   Publishing others' private information, such as a physical or email address, without their explicit permission
+
+-   Other conduct which could reasonably be considered inappropriate in a professional setting
+
+Enforcement Responsibilities
+----------------------------
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+Scope
+-----
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+Enforcement
+-----------
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <info@developmentgateway.org> . All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+Enforcement Guidelines
+----------------------
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1\. Correction
+
+Community Impact: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+Consequence: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2\. Warning
+
+Community Impact: A violation through a single incident or series of actions.
+
+Consequence: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3\. Temporary Ban
+
+Community Impact: A serious violation of community standards, including sustained inappropriate behavior.
+
+Consequence: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4\. Permanent Ban
+
+Community Impact: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+Consequence: A permanent ban from any sort of public interaction within the community.
+
+Attribution
+-----------
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at <https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -47,7 +47,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 Enforcement
 -----------
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <info@developmentgateway.org> . All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <info@developmentgateway.org>. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,15 +30,6 @@ cd wp-react-lib/wp-react-lib
 pnpm install
 ```
 
-### Secrets scanning (pre-commit hook)
-
-This project uses [Gitleaks](https://github.com/gitleaks/gitleaks) to prevent secrets from being accidentally committed. Install the hook after cloning:
-
-```bash
-pip install pre-commit
-pre-commit install
-```
-
 ### Build in watch mode
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,145 @@
-## Contributing code back to **wp-react-lib**
+# Contributing to wp-react-lib
 
-There are several ways in which this can be achieved:
+Thank you for your interest in contributing. This project is maintained by [Development Gateway](https://www.developmentgateway.org/). `@devgateway/wp-react-lib` is a library for integrating React applications with WordPress via the REST API.
 
-### Forking **wp-react-lib** for a feature/fix development
+## Table of Contents
 
-The best and easiest is to fork **wp-react-lib** for the sole purpose of developing a new module/feature/fix. You can very well use your own private github user space to do this and thus you can use the FORK button on the Ghihub page. After the fork you can commit all your new stuff to your copy of wp-react-lib then ask for a Pull Request of your code back into wp-react-lib project. 
+- [Development Setup](#development-setup)
+- [Branching Model](#branching-model)
+- [Making Changes](#making-changes)
+- [Commit Messages](#commit-messages)
+- [Code Style](#code-style)
+- [Opening a Pull Request](#opening-a-pull-request)
+- [License](#license)
+- [Security](#security)
 
-### Develop the contributions in an already forked project
+---
 
-Yes, it would be cool if we could develop the new contribution as part of your current project, which was forked some time ago from **wp-react-lib**. It is possible but it is a bit trickier. You will not be able to merge your project back to **wp-react-lib**, because this will bring all your project's custom code into this project, so basically the customized implementation the client has asked for, like custom React components that it asked. That is undesirable.
+## Development Setup
 
-One simple solution to this is to commit the changes you are willing to merge back to **wp-react-lib** as atomic changes. That means that when you commit your files, you commit only those files that are related to that new feature and nothing else. For example let's suppose you want to develop a new chart component using Nivo library and then you will like to merge this new module to **wp-react-lib**. You should commit all the code that has to do with the search module in separate commits that do not contain other code, for example if the chart component has some specific part that is tied to the client implementation, you will commit that linking in a separate commit, so keep the commits that target the module functionality separate. 
+### Prerequisites
 
-Then, you can cherry-pick your project's branch over the **wp-react-lib** remote branch. By doing so, you can pick what commits to apply and what to leave out and you will choose only the commits that implement the generic new module functionality and you will leave out the client-specific customizations that are not meant to be posted to **wp-react-lib**.
+- Node.js v22+
+- pnpm v10+
 
-And thanks for contributing to this project!
+### Install
+
+```bash
+git clone git@github.com:devgateway/wp-react-lib.git
+cd wp-react-lib/wp-react-lib
+pnpm install
+```
+
+### Secrets scanning (pre-commit hook)
+
+This project uses [Gitleaks](https://github.com/gitleaks/gitleaks) to prevent secrets from being accidentally committed. Install the hook after cloning:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+### Build in watch mode
+
+```bash
+pnpm dev
+```
+
+### Build once
+
+```bash
+pnpm build
+```
+
+---
+
+## Branching Model
+
+- `main` is the stable branch and the base for all pull requests.
+- Create a branch off `main` for every change, using a prefix that matches the Conventional Commits type: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, or `ci/`.
+- Do not push directly to `main`.
+
+---
+
+## Making Changes
+
+### Adding a changeset
+
+Every PR that changes published behaviour must include a changeset:
+
+```bash
+pnpm changeset
+```
+
+Select `@devgateway/wp-react-lib`, choose the bump type, and write a one-line changelog description.
+
+| Change type | Bump |
+|---|---|
+| Breaking API change | `major` |
+| New hook, component, or export | `minor` |
+| Bug fix, refactor, dependency update | `patch` |
+
+---
+
+## Commit Messages
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/). Use a prefix that reflects the nature of the change:
+
+| Prefix | When to use |
+|---|---|
+| `feat:` | New hook, component, or user-facing feature |
+| `fix:` | Bug fix |
+| `chore:` | Dependency update, tooling, config |
+| `docs:` | Documentation only |
+| `refactor:` | Code restructure with no behaviour change |
+| `ci:` | CI/CD workflow changes |
+
+For breaking changes append `!` to the prefix, and add a `BREAKING CHANGE:` footer in the commit body:
+
+```
+feat(wp-react-lib)!: rename usePost return shape
+
+BREAKING CHANGE: usePost now returns { data, loading, error } instead of a flat object
+```
+
+Examples:
+```
+feat(wp-react-lib): add useMenuItems hook
+fix(wp-react-lib): correct SSR window guard in usePost
+chore: upgrade immutable to 5.1.3
+```
+
+---
+
+## Code Style
+
+- TypeScript for all new source files
+- Keep the library generic — no application-specific or client-specific logic
+- Contributions that tightly couple to a particular WordPress setup will be asked to be extracted or made configurable
+
+---
+
+## Opening a Pull Request
+
+Forking is not enabled on this repository. To contribute, request access from a maintainer, then create a branch directly in this repo off `main`.
+
+1. Create a branch off `main` (see [Branching Model](#branching-model))
+2. Make your changes and add a changeset
+3. Ensure `pnpm build` passes locally
+4. Open a PR against `main` with a clear description of what changed and why
+5. At least one maintainer approval is required before merging
+6. All CI checks must pass
+
+Do not introduce hardcoded credentials, internal URLs, client-specific identifiers, or PII. Ensure any new dependency has an Apache-2.0-compatible license.
+
+---
+
+## License
+
+By contributing you agree that your contributions are licensed under the [Apache License 2.0](LICENSE).
+
+---
+
+## Security
+
+Please do not report security vulnerabilities through public GitHub issues. See [SECURITY.md](SECURITY.md) for the responsible disclosure process.

--- a/README.md
+++ b/README.md
@@ -151,11 +151,13 @@ Please look at **wp-react-example-advanced** and **wp-react-blocks-plugin**
 
 For details about how to send pull requests, please read [CONTRIBUTING.md](https://github.com/devgateway/wp-react-lib/blob/main/CONTRIBUTING.md).
 
-## Autor
+## Author
 
 * **Sebastian Dimunzio** - *Architecture and code* - [sdimunzio](https://github.com/sdimunzio)
 
-The list of all contributors to this project can be read at [contributors](https://github.com/devgateway/wp-react-lib/graphs/contributors).
+## Contributors
+
+* **Timothy Gachengo** - *Refactoring* - [timothygachengo](https://github.com/timothygachengo)
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release on the `main` branch receives security fixes.
+
+| Version | Supported |
+|---------|-----------|
+| Latest (main) | Yes |
+| Older releases | No |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues, pull requests, or discussions.**
+
+To report a vulnerability privately, use one of the following methods:
+
+### Option 1 — GitHub Private Vulnerability Reporting (preferred)
+
+Use GitHub's built-in [private vulnerability reporting](https://github.com/devgateway/wp-react-lib/security/advisories/new) feature. Your report will be visible only to repository maintainers.
+
+### Option 2 — Email
+
+Send a description of the vulnerability to <info@developmentgateway.org>. Include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- Affected package(s) and version(s)
+- Any suggested mitigations
+
+## What to Expect
+
+- **Acknowledgement:** within 5 business days of receipt
+- **Status update:** within 15 business days
+- **Fix timeline:** depends on severity; critical issues are prioritized
+- **Credit:** reporters will be credited in the security advisory unless they request anonymity
+
+## Scope
+
+This policy covers vulnerabilities in code maintained in this repository:
+
+- `wp-react-lib` (`@devgateway/wp-react-lib`)
+
+### Out of Scope
+
+- Vulnerabilities in WordPress itself — report to the [WordPress Security Team](https://wordpress.org/about/security/).
+- Vulnerabilities only exploitable with valid admin credentials to the running application.

--- a/wp-react-lib/package.json
+++ b/wp-react-lib/package.json
@@ -1,7 +1,10 @@
 {
   "name": "@devgateway/wp-react-lib",
   "version": "0.6.2",
-  "author": "Sebastian Dimunzio <sdimunzio@developmentgateway.org/>",
+  "author": "Sebastian Dimunzio <sdimunzio@gmail.com>",
+  "contributors": [
+    "Timothy Gachengo (https://github.com/timothygachengo)"
+  ],
   "type": "module",
   "files": [
     "dist",
@@ -10,7 +13,7 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "immutable": "^5.1.3",
     "react": "^18.3.1",
@@ -48,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/devgateway/dg-wp-react.git",
+    "url": "git+https://github.com/devgateway/wp-react-lib.git",
     "directory": "wp-react-lib"
   },
   "keywords": [


### PR DESCRIPTION
## Description

Aligns wp-react-lib with the governance policy established across data-viz-ui, data-viz-api, and data-viz-wordpress.

## Changes

- **CONTRIBUTING.md** — full rewrite: replaces old fork-based instructions with the standard policy (no-fork model, access-request flow, Conventional Commits table with all prefixes including `ci/`, `!` breaking change notation, changeset guide)
- **SECURITY.md** — new file: private vulnerability reporting via GitHub advisories, email fallback, SLAs, scope
- **CODE_OF_CONDUCT.md** — new file: Contributor Covenant v2.1
- **wp-react-lib/package.json** — fix author email (trailing slash removed), license `MIT` → `Apache-2.0`, add `contributors` field, fix stale repository URL (`dg-wp-react` → `wp-react-lib`)

## Type of change

- [x] Documentation update (`docs:`)
- [x] Refactor / chore (`chore:`)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] No hardcoded credentials, internal URLs, client names, or PII introduced